### PR TITLE
+reincluded a notion of numV

### DIFF
--- a/MSE-lang-design.rkt
+++ b/MSE-lang-design.rkt
@@ -1,0 +1,264 @@
+#lang plai
+
+
+;; ==========================================================
+;;                     EBNF & DEFINE-TYPES
+;; ==========================================================
+
+
+;; Sample markov table
+
+;; C4 B4 C4 D4
+
+; C4 | B4 D4
+; B4 | C4
+; D4 | C4 ; Implicitly first note follows the last note
+
+; Example : (markov '(C4 B4 C4 D4) 11) => (C4 B4 C4 D4 C4 B4 C4 D4 C4 B4 C4)
+
+
+;; MSE = Music Writing Expression
+;;
+;; <MSE> ::= <num>
+;;     | <id>
+;;     | {note <MSE> <MSE> <MSE>}                ;Notes can take either numbers, or ids for their values
+;;     | {sequence <MSE>*}
+;;     | {seq-append <MSE> to <MSE>}             ; Appends the 2nd MSE Expression to
+;;                                                    the end of the first
+;;     | {with {<id> <MSE>} <MSE>}     
+;;     | {fun {<id> <MSE>} <MSE>}
+;;     | {<MSE> <MSE> }                          ; function calls, any time the first symbol is not a reserved word
+;;     | {interleave <MSE> into <MSE>}           ; Takes first element of 1st MSE, appends to 1st element of 2nd MSE ... 
+;;     | {insert <MSE> in <MSE> at <num>}        ; Inserts MSE in MSE at index number
+;;     | {transpose <MSE> <num>}                 ; Takes a sequence of notes and a number, and
+;;                                                    adds that number to the pitch of all notes in the sequence
+;;     | {markov <MSE> <num> <MSE>?}             ; Runs markov chain (with a depth of 1) as shown in the example above
+
+; Note Message is 3 bytes
+; Pitch (0 - 127)
+; Velocity (How hard you hit it) (0 - 127)
+; Duration (Time in milliseconds)
+
+
+;;;;;;;;;;;;;;;;   Type-Definitions   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; MSE 
+(define-type MSE
+  [num (n number?)]
+  [id (name symbol?)]
+  [note (pitch MSE?) (vel MSE?) (dur MSE?)] ; Pitch, Velocity, Duration
+  [sequence (values (listof note?))]                  ; Distributions must not be empty and strictly evaluate to a (listof Note)
+  [seqn-p (values (listof MSE?))]
+  [seq-append (list1 MSE?) (list2 MSE?)]              
+  [with (id symbol?) (expr MSE?) (body MSE?)]
+  [fun (param symbol?) (body MSE?)]
+  [app (function MSE?) (arg MSE?)]
+  [interleave (list1 MSE?) (list2 MSE?)]
+  [insert (list1 MSE?) (list2 MSE?) (index num?)]
+  [transpose (list1 MSE?) (add-val num?)]
+  [markov (seed MSE?) (length num?) (initial-note MSE?)] ; initial-note has to evaluate to a note
+  )
+
+;; Environments store values, instead of substitutions
+(define-type Env
+  [mtEnv]
+  [anEnv (name symbol?) (value MSE-Value?) (env Env?)])
+
+;; Interpreting a value returns a Value
+(define-type MSE-Value
+  ; Sequence of  Notes
+  [numV (n number?)]        
+  [pitchV (pit number?)]
+  [velV (vel number?)]
+  [durV (dur number?)]
+  [noteV (p pitchV?) (vel velV?) (dur durV?)]
+  [seqV (values (and/c (listof MSE-Value?) (not/c empty?)))] ;;Distributions must not be empty
+  [closureV (param symbol?)  ;;Closures wrap an unevaluated function body with its parameter and environment
+            (body MSE?)
+            (env Env?)])
+
+
+;; for interpreter
+;; exclude seq-append and with
+;; TODO, why is this a thing? not ever used.
+(define-type D-MSE
+  [i-num (n number?)]
+  [i-id (name symbol?)]
+  [i-note (pitch D-MSE?) (vel D-MSE?) (dur D-MSE?)]
+  [i-sequence (values (listof note?))]
+  [i-fun (param symbol?) (body D-MSE?)]
+  [i-app (function D-MSE?) (arg D-MSE?)]
+  [i-interleave (list1 D-MSE?) (list2 D-MSE?)]
+  [i-insert (list1 D-MSE?)(list2 D-MSE?)(index num?)]
+  [i-transpose (list1 D-MSE?)(add-val num?)]
+  [i-markov (seed D-MSE?)(length num?)(initial-note D-MSE?)]
+  )
+
+
+(define *reserved-symbols* '(note sequence seq-append with interleave insert transpose markov)) ; defining what the reserved symbols of the system are
+
+
+
+
+;;;;;;;;;;;;;;;;   PARSER   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; valid-identifier? : symbol -> boolean
+;; Returns whether the given input is a symbol and a valid identifier
+(define (valid-id? sym)
+  (and (symbol? sym)
+       ;;TODO add pitch rejection
+       (not (member sym *reserved-symbols*))))
+
+;;parse s-exp -> MSE
+;;Parses s-exp input and does valid-id checking for binding sites
+(define (parse sexp)
+  (match sexp
+    [(? number?) (num sexp)]
+    [(? symbol?) (id sexp)]
+    [(list 'note pitch vel dur) (note (parse pitch) (parse vel) (parse dur))]
+    [(cons 'sequence notes) (sequence (map parse notes))]
+    [(cons 'seqn-p notes) (seqn-p  (map parse notes))]
+    [(list 'seq-append list1 list2) (seq-append (parse list1) (parse list2))]
+    [(list 'with (list (? valid-id? id) value) body) (with id (parse value) (parse body))]
+    [(list 'fun (? valid-id? param) body) (fun param (parse body))]
+    [(list (and f-expr (? (lambda (s) (not (member s *reserved-symbols*))))) a-expr)
+     (app (parse f-expr) (parse a-expr))]
+    [(list 'interleave list1 list2) (interleave (parse list1) (parse list2))]
+    [(list 'insert list1 list2 index) (insert (parse list1) (parse list2) (parse index))]
+    [(list 'transpose list1 add-val) (transpose (parse list1) (parse add-val))]
+    [(list 'markov seed length initial-note) (markov (parse seed) (parse length) (parse initial-note))]))
+
+
+;;;;;;;;;;;;;;;;   DESUGARER   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;desugar MSE -> MSE
+(define (desugar p-mse)
+  (type-case MSE p-mse
+    [num (n) (num n)]
+    [id (val) (id val)]
+    [note (p v d) (note (desugar p)
+                        (desugar v)
+                        (desugar d))]
+    [sequence (vals) (sequence (map desugar vals))]
+    [seqn-p (vals) (seqn-p (map desugar vals))]
+    [seq-append (seq1 seq2)
+                (insert (desugar seq1)
+                        (desugar seq2)
+                        (num (length (sequence-values (desugar seq1)))))] 
+    [with (id named-expr body) (desugar (app (fun id body) named-expr))]
+    [fun (param body) (fun param (desugar body))]
+    [app (fn-exp arg-exp) (app (desugar fn-exp)
+                               (desugar arg-exp))]
+    [interleave (lst1 lst2)
+                (interleave (desugar lst1)(desugar lst2))]
+    [insert (lst1 lst2 index)
+            (insert (desugar lst1)(desugar lst2)(desugar index))]
+    [transpose (lst1 anum)
+               (transpose (desugar lst1)(desugar anum))]
+    [markov (s lth ini)
+            (markov (desugar s)(desugar lth)(desugar ini))]
+    ))
+
+
+
+;;;;;;;;;;;;;;;;   INTERPRETER   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;decode-pitch symbol -> number        
+(define (decode-pitch sym)
+  (match sym
+    [(? symbol?) (match (symbol->string sym)
+                   [(regexp #rx"[A-G](#|b)*[0-9]+$") (numV (+ (match (regexp-match #rx"[A-G]" (symbol->string sym))
+                                                        ['("C") 0]
+                                                        ['("D") 2]
+                                                        ['("E") 4]
+                                                        ['("F") 5]
+                                                        ['("G") 7]
+                                                        ['("A") 9]
+                                                        ['("B") 11])
+                                                      (match (regexp-match #rx"b|#" (symbol->string sym)) ;;TODO, count quantity of sharp/flat
+                                                        ['("b") -1]
+                                                        ['("#") 1]
+                                                        [else 0])
+                                                      (* (string->number (first (regexp-match #rx"[0-9]+" (symbol->string sym)))) 12)))]
+                    [else (error "Not a valid pitch: " sym)])]
+    [else (error "Not a valid pitch: " sym)]
+    ))
+
+;;lookup symbol -> MSE
+(define (lookup name env)
+  (local ([define (lookup-helper name env)
+            (type-case Env env
+              [mtEnv () (error 'lookup "free identifier ~a" name)]
+              [anEnv (bound-name bound-value rest-env)
+                     (if (symbol=? bound-name name)
+                         bound-value
+                         (lookup-helper name rest-env))])]
+          [define (pitch-check name)
+            (match (symbol->string name)
+                   [(regexp #rx"[A-G](#|b)*[0-9]+$") true]
+                   [else false])])
+    (if (pitch-check name)
+        (decode-pitch name) 
+        (lookup-helper name env))))
+
+
+;;interp MSE -> MSE-Value
+(define (interp d-mse)
+  (local [(define (transOne val m env)
+            (type-case MSE m
+              [note (p v d)  (note (num (+ (helper val env) (helper p env))) v d)]
+              [else (transOne val
+                              (type-case MSE-Value (helper m env)
+                                [noteV (p v d) (note p v d)]
+                                [else "need a note"]) env)]))
+          (define (doInsert lis2 lis n)
+            (cond [(> n (length lis)) (append lis lis2)]
+                  [(= n 0)(append lis2 lis)]
+                  [else
+                   (cons (first lis) (doInsert lis2 (rest lis) (sub1 n)))]))
+          (define (tolist seq)
+            (type-case MSE seq
+              [sequence (l) l]
+              [else (error "need a sequence")]))
+          (define (inter lis1 lis2)
+            (cond [(empty? lis1) lis2]
+                  [(empty? lis2) lis1]
+                  [else (cons (first lis1)
+                              (cons (first lis2)
+                                    (inter (rest lis1) (rest lis2))))]))
+          ;(define (markov lis 
+          (define (helper expr env)
+            (type-case MSE expr
+              [num (n) (numV n)]
+              [note (p v d) (noteV (pitchV (numV-n  (helper p env)))
+                                   (velV (numV-n  (helper v env)))
+                                   (durV (numV-n  (helper d env))))]
+              [id  (name)  (lookup name env)]
+              [sequence (vals) (seqV (map (lambda (exp) (helper exp env)) vals))]
+              [seqn-p (syms) (seqV (map (lambda (sym) (noteV (pitchV (helper sym env))
+                                                           (velV (num 10))
+                                                           (durV (num 10)))) syms))]
+              [fun (arg-name body) (closureV arg-name body env)]
+              [app (fun-expr arg-expr)
+                   (local ([define fun-val (helper fun-expr env)]
+                           [define arg-val (helper arg-expr env)])
+                     (helper (closureV-body fun-val)
+                             (anEnv (closureV-param fun-val) arg-val (closureV-env fun-val))))]
+              [interleave (l1 l2) (helper (sequence (inter (tolist l1) (tolist l2))) env)]
+              [insert (l1 l2 index) (helper (sequence (doInsert (tolist  l1 ) (tolist  l2) (numV-n (helper index env)))) env)]
+              [transpose (listN value)  (helper (sequence (map (lambda (m) (transOne value m env)) (tolist listN))) env) ]
+              [else "NO!!!"]))]
+    (helper d-mse (mtEnv))))
+
+
+
+;;Run MSE -> MSE-Value
+;;Interprets the result of desugaring the parse s-expression
+(define (run mse)
+  (interp (desugar (parse mse))))
+
+

--- a/MSE-tests.rkt
+++ b/MSE-tests.rkt
@@ -1,0 +1,131 @@
+#lang plai
+
+
+;(print-only-errors)
+
+(require "MSE-lang-design.rkt")
+
+
+;;Testing for MSE lang
+
+;;;;;;;;;;;;;;;;   define-type tests   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+;;;;;;;;;;;;;;;;   PARSER tests   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;TODO!
+
+;;;;;;;;;;;;;;;;   DESUGARER tests   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; sequence
+(test (desugar (parse '{sequence {note 40 50 60}}))
+      (sequence (list (note (num 40) (num 50) (num 60)))))
+(test (desugar (parse '{sequence {note 40 50 60}
+                                 {note 50 60 70}}))
+      (sequence (list (note (num 40) (num 50) (num 60))
+                      (note (num 50) (num 60) (num 70)))))
+;; seq-append
+(test (desugar (parse '{seq-append
+                        {sequence {note 30 40 50}
+                                  {note 20 30 40}}
+                        {sequence {note 40 50 60}}}))
+      (insert
+       (sequence
+         (list (note (num 30) (num 40) (num 50))
+               (note (num 20) (num 30) (num 40))))
+       (sequence (list (note (num 40) (num 50) (num 60))))
+       (num 2)))
+
+;; with
+(test (desugar (parse '{with {c
+                              {sequence {note 10 20 30}}}
+                             c}))
+      (app (fun 'c (id 'c))
+           (sequence (list (note (num 10) (num 20) (num 30))))))
+;; interleave
+(test (desugar (parse '{interleave {sequence {note 30 40 50}}
+                                   {sequence {note 40 50 60}}}))
+      (interleave
+       (sequence (list (note (num 30) (num 40) (num 50))))
+       (sequence (list (note (num 40) (num 50) (num 60))))))
+;; insert
+(test (desugar (parse '{insert {sequence {note 20 30 40}}
+                               {sequence {note 30 40 50}
+                                         {note 40 50 60}
+                                         {note 10 20 30}}
+                               2}))
+      (insert
+       (sequence (list (note (num 20) (num 30) (num 40))))
+       (sequence
+         (list
+          (note (num 30) (num 40) (num 50))
+          (note (num 40) (num 50) (num 60))
+          (note (num 10) (num 20) (num 30))))
+       (num 2)))
+;; transpose
+(test (desugar (parse '{transpose {sequence {note 30 40 50}} 14}))
+      (transpose (sequence (list (note (num 30) (num 40) (num 50)))) (num 14)))
+;; markov
+(test  (desugar (parse '{markov
+                         {sequence {note 20 30 40}
+                                   {note 30 40 50}
+                                   {note 40 50 60}}
+                         20
+                         {sequence {note 20 30 40}}}))
+       (markov
+        (sequence
+          (list
+           (note (num 20) (num 30) (num 40))
+           (note (num 30) (num 40) (num 50))
+           (note (num 40) (num 50) (num 60))))
+        (num 20)
+        (sequence (list (note (num 20) (num 30) (num 40))))))
+
+
+
+
+
+
+;;;;;;;;;;;;;;;;   INTERPRETER tests   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(test (run '10) (numV 10))
+
+(test (run '{note 10 20 30})
+      (noteV (pitchV 10) (velV  20) (durV 30)))
+
+
+(test (run '{note C4 20 30})
+      (noteV (pitchV 48) (velV  20) (durV 30)))
+
+(test (run '{with {c 10} c}) (numV 10))
+
+(test/exn (run '{with {C4 10} C4}) "") ;restricted pitch identifier
+      
+(test (run '{with {c {sequence {note 10 20 30}}}
+                             c})
+      (seqV (list (noteV (pitchV 10) (velV 20) (durV  30)))))
+
+(test (run '(interleave (sequence (note 10 20 30) (note 20 20 20)) (sequence (note 30 20 10) (note 30 30 30))))
+(seqV
+ (list
+  (noteV (pitchV 10) (velV 20) (durV 30))
+  (noteV (pitchV 30) (velV 20) (durV 10))
+  (noteV (pitchV 20) (velV 20) (durV 20))
+  (noteV (pitchV 30) (velV 30) (durV 30)))))
+
+(test (run '(interleave (sequence (note 10 20 30)) (sequence (note 30 20 10) (note 30 30 30))))
+(seqV (list (noteV (pitchV 10) (velV 20) (durV 30))
+            (noteV (pitchV 30) (velV 20) (durV 10))
+            (noteV (pitchV 30) (velV 30) (durV 30)))))
+
+(test (run '(seq-append (sequence (note 10 20 30) (note 20 20 20)) (sequence (note 30 20 10) (note 30 30 30))))
+(seqV
+ (list
+  (noteV (pitchV 30) (velV 20) (durV 10))
+  (noteV (pitchV 30) (velV 30) (durV 30))
+  (noteV (pitchV 10) (velV 20) (durV 30))
+  (noteV (pitchV 20) (velV 20) (durV 20)))))


### PR DESCRIPTION
Main:
+redefined pitchV, durV, and velV to not recursively include num or numV
+moved all define-types to the top

Interp changes:
+pitchV, durV, and velV recursively interp their values, allows for ID dereferencing 
+extract the value of numV to embed in value of pitchV, durV, and velV

Testing:
+labeled some testing cases
+included more base case testing for interp

TODO:
>include pitch identifiers as restricted IDs for binding sites